### PR TITLE
[x] Resume -> [✓] News

### DIFF
--- a/frontend/src/AboutMe.tsx
+++ b/frontend/src/AboutMe.tsx
@@ -19,7 +19,7 @@ const paragraphs: string[] = [
   "Since then, I've interned, researched, and tutored in the field, and I'm actively looking for which niche I can nestle into within CS.",
   "Whatever that may be, I'm confident that I'll use my moral compass to build empowering, robust software that can advance the world.",
   "- - -",
-  "Aside from coding, of course ;), I enjoy reading and writing comic books, watching movies, playing cool board games (particularly 'Sherriff of Nottingham', trying new food, and playing around with my dog.",
+  "Aside from coding, of course ;), I enjoy reading and writing comic books, watching movies, playing cool board games (particularly 'Sherriff of Nottingham'), trying new food, and playing around with my dog.",
   "Thanks for reading, and I hope you check out the rest of the site. Peace, and God bless =).",
 ];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import Footer from "./Footer";
 import IntroBlurb from "./IntroBlurb";
 import Projects from "./Projects";
 import ResponsiveHeader from "./ResponsiveHeader";
-import Resume from "./Resume";
+import InTheNews from "./InTheNews";
 import { urlProp } from "./CustomTypes";
 
 const App = () => {
@@ -25,7 +25,7 @@ const App = () => {
       <Route exact path="/aboutme" component={AboutMe} />
       <Route exact path="/contact" component={ContactMe} />
       <Route path="/projects" component={Projects} />
-      <Route path="/resume" component={Resume} />
+      <Route path="/news" component={InTheNews} />
 
       <Footer url={footerProps.url} hyperlinkName={footerProps.hyperlinkName} />
     </Router>

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
       <HeaderButton toPath="" isHomeButton={true} />
 
       <Filler flexSize={1} />
-      <HeaderButton buttonName="Résumé" toPath="resume" />
+      <HeaderButton buttonName="News Links" toPath="news" />
 
       <Filler flexSize={1} />
       <HeaderButton buttonName="Contact Me" toPath="contact" />

--- a/frontend/src/InTheNews.tsx
+++ b/frontend/src/InTheNews.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const InTheNews = () => {
+  return (
+    <div>
+      <h1>in the news</h1>
+    </div>
+  );
+};
+
+export default InTheNews;

--- a/frontend/src/Resume.tsx
+++ b/frontend/src/Resume.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const Resume = () => {
-  return <h1>resume page</h1>;
-};
-
-export default Resume;


### PR DESCRIPTION
- I decided to remove the ``resume`` button/section of the website, instead opting for a ``news`` section
  - my reasoning was that the resume would be largely redundant since everything on my PDF resume is on LinkedIn